### PR TITLE
Reproduce issue 1: Retrieving network printer status fails after subsequent attempts

### DIFF
--- a/src/commonMain/kotlin/com/shopify/library/internal/star/StarSdk.kt
+++ b/src/commonMain/kotlin/com/shopify/library/internal/star/StarSdk.kt
@@ -3,6 +3,7 @@ package com.shopify.library.internal.star
 interface StarSdk {
     suspend fun searchPrinters(target: StarQuery): List<PortInfo>
     suspend fun print(port: Port, releasePort: Boolean): Boolean
+    suspend fun getWifiPrinterStatus(portInfo: PortInfo, timesToReleasePort: Int): String
 
     enum class StarQuery(val query: String) {
         Bluetooth("BT:"),

--- a/src/ios/StarSampleApp/StarSampleApp/viewmodel/PrinterDetailsViewModel.swift
+++ b/src/ios/StarSampleApp/StarSampleApp/viewmodel/PrinterDetailsViewModel.swift
@@ -51,6 +51,8 @@ class PrinterDetailsViewModel: ObservableObject {
         isPrinting = true
         starManager?.print(releasePort: releasePort)
     }
+
+    func getWifiPrinterStatus(portInfo: PortInfo, timesToReleasePort: Int32) {
+        starManager?.getWifiPrinterStatus(portInfo: portInfo, timesToReleasePort: timesToReleasePort)
+    }
 }
-
-

--- a/src/ios/StarSampleApp/StarSampleApp/views/PrinterDetailsView.swift
+++ b/src/ios/StarSampleApp/StarSampleApp/views/PrinterDetailsView.swift
@@ -21,11 +21,11 @@ struct PrinterDetailsView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10.0) {
                 Text(portInfo.modelName).font(.largeTitle)
-                Text(portInfo.macAddress)
-                Text(portInfo.portName)
+                Text("MAC address: \(portInfo.macAddress)")
+                Text("Port name: \(portInfo.portName)")
                 
                 if let status = viewModel.printerStatus {
-                    Text(status)
+                    Text("Printer status: \(status)")
                 }
                 HStack(spacing: 20.0) {
                     Button("Print and release port", action: {
@@ -35,7 +35,16 @@ struct PrinterDetailsView: View {
                     Button("Print do not release port", action: {
                         viewModel.print(releasePort: false)
                     }).disabled(viewModel.isPrinting || viewModel.printerStatus == "Uninitialized")
-                }
+                }.padding(.top, 40.0)
+                HStack(spacing: 20.0) {
+                    Button("Get status, release port ONCE", action: {
+                        viewModel.getWifiPrinterStatus(portInfo: portInfo, timesToReleasePort: 1)
+                    })
+
+                    Button("Get status, release port TWICE", action: {
+                        viewModel.getWifiPrinterStatus(portInfo: portInfo, timesToReleasePort: 2)
+                    })
+                }.padding(.top, 20.0)
             }.padding()
         }.frame(
             minWidth: 0,


### PR DESCRIPTION
Adds the ability to reproduce the issue where retrieving network printer statuses fails after multiple attempts. Getting a printer status works correctly the first time, but fails the second time with the following error:

```
Failed to getPort. Printer is in use.
```

During development it was discovered that calling `SMPort.releasePort(port)` twice will successfully release the port and the status can be retrieved, whereas calling it only once will not.

STR:
1. Turn on a Wi-Fi printer.
2. Launch the app and press `Scan Network` for the app to discover the Wi-Fi printer. Select the printer from the list.
3. On the printer details page, press `Get status, release port TWICE`. Verify the printer status changes to `Online`.
4. Press `Get status, release port TWICE` a few more times, verifying the status is always `Online`.
5. Press `Get status, release port ONCE`, verify the status is `Online`.
6. Press `Get status, release port ONCE` again, and verify the status changes to `Offline` after a few seconds, with the following error message logged. Any subsequent attempt to get the printer status will result in this failure.

```
StarSampleApp[509:56850] Failed to open printer port, with an error of: Error Domain=jp.star-m.stario Code=-100 "Failed to getPort. Printer is in use." UserInfo={NSLocalizedDescription=Failed to getPort. Printer is in use.}
```