### PR TITLE
Add ability to search for ALL printers

### DIFF
--- a/src/commonMain/kotlin/com/shopify/library/internal/star/StarManager.kt
+++ b/src/commonMain/kotlin/com/shopify/library/internal/star/StarManager.kt
@@ -49,6 +49,14 @@ class StarManager(
         }
     }
 
+    fun discoverAllPrinters() {
+        backgroundScope.launch {
+            starSdk.searchPrinters(StarSdk.StarQuery.All).also {
+                _printers.emit(it)
+            }
+        }
+    }
+
     fun connect(portName: String) {
         starIoExtManagerWrapper.connect(portName = portName)
     }

--- a/src/commonMain/kotlin/com/shopify/library/internal/star/StarSdk.kt
+++ b/src/commonMain/kotlin/com/shopify/library/internal/star/StarSdk.kt
@@ -13,6 +13,7 @@ interface StarSdk {
     enum class StarQuery(val query: String) {
         Bluetooth("BT:"),
         Network("TCP:"),
-        Usb("USB:")
+        Usb("USB:"),
+        All("All:")
     }
 }

--- a/src/ios/StarSampleApp/StarSampleApp/viewmodel/PrinterListViewModel.swift
+++ b/src/ios/StarSampleApp/StarSampleApp/viewmodel/PrinterListViewModel.swift
@@ -40,6 +40,12 @@ class PrinterListViewModel: ObservableObject {
         isSearching = true
         starManager?.discoverNetworkPrinters()
     }
+    
+    func discoverAllPrinters() {
+        printerList = []
+        isSearching = true
+        starManager?.discoverAllPrinters()
+    }
 }
 
 class Collector<T>: Kotlinx_coroutines_coreFlowCollector {

--- a/src/ios/StarSampleApp/StarSampleApp/views/PrinterListView.swift
+++ b/src/ios/StarSampleApp/StarSampleApp/views/PrinterListView.swift
@@ -25,6 +25,9 @@ struct PrinterListView: View {
                     Button("Scan Network", action: {
                         viewModel.discoverNetworkPrinters()
                     })
+                    Button("Scan All", action: {
+                        viewModel.discoverAllPrinters()
+                    })
                 }.padding()
                 if let list = viewModel.printerList {
                     List(list, id: \.macAddress) { portInfo in


### PR DESCRIPTION
Just like Bluetooth and Network, add ability to search for Star printers with all connection types to the sample app. I added this as I was tinkering around with the `All` search query to see if it sped up printer discovery (it doesn't), but I figured I might as well put up a PR to permanently add the functionality.