### PR TITLE
Bluetooth connection issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@
 #### Star Bluetooth printer with an active StarIoExtManager connection won't reconnect after calling `disconnect()` when app is backgrounded and `connect()` when app is foregrounded.
 
   **Bug description:**
-This sample app will use a `StarIoExtManager` to connect with a Bluetooth printer.  Once connected, the app will automatically call `starIoExtManager.disconnect()` if the app is subsequently backgrounded, and then `starIoExtManager.connect()` if the app is brought into the foreground again.  However if the printer is switched off while the app is backgrounded, and then switched on _after_ the app has been foregrounded again, the `StarIoExtManager` will fail to reconnect to the printer and report the following error:
-
-<insert error message from Star Micronics SDK>
+This sample app will use a `StarIoExtManager` to connect with a Bluetooth printer.  Once connected, the app will automatically call `starIoExtManager.disconnect()` if the app is subsequently backgrounded, and then `starIoExtManager.connect()` if the app is brought into the foreground again.  However if the printer is switched off while the app is backgrounded, and then switched on _after_ the app has been foregrounded again, the `StarIoExtManager` will fail to reconnect to the printer and report the following error: "Failed to initialize printer"
 
 The only way to get the printer to connect to the sample app again is to force close and restart the app.
+  
   **Steps to reproduce:**
   1. Manually pair a Star Micronics Bluetooth printer to the iOS device
   2. On the sample app, click the "Scan BT" button to discover the paired BT printer

--- a/README.md
+++ b/README.md
@@ -2,28 +2,31 @@
 
 ## iOS Bugs
 
-#### Star Bluetooth printer with an active StarIoExtManager connection won't reconnect after calling disconnect()/connect()
+#### Star Bluetooth printer with an active StarIoExtManager connection won't reconnect after calling `disconnect()` when app is backgrounded and `connect()` when app is foregrounded.
 
-  **Background:**
-  This regression was introduced after addressing another bug which involved swapping between our Point of Sale app and opening another 3rd party app that also makes a connection to the BT printer. Previously we were not calling disconnec() when backgrounding and not calling connect() when foregrounding our app, and would lose connection to the Printer. After adding calls to disconnect/connect when background/foregrounding it addressed our initial connection issue, but introduced a new regression when powering off the BT printer during backgrounding and not being able to connect after powering it back on after foregrounding.
+  **Bug description:**
+This sample app will use a `StarIoExtManager` to connect with a Bluetooth printer.  Once connected, the app will automatically call `starIoExtManager.disconnect()` if the app is subsequently backgrounded, and then `starIoExtManager.connect()` if the app is brought into the foreground again.  However if the printer is switched off while the app is backgrounded, and then switched on _after_ the app has been foregrounded again, the `StarIoExtManager` will fail to reconnect to the printer and report the following error:
 
+<insert error message from Star Micronics SDK>
+
+The only way to get the printer to connect to the sample app again is to force close and restart the app.
   **Steps to reproduce:**
   1. Manually pair a Star Micronics Bluetooth printer to the iOS device
   2. On the sample app, click the "Scan BT" button to discover the paired BT printer
   3. Click on the discovered BT printer row to navigate to printer details
   4. In the top right, click "Connect" - wait for the connection to succeed 
   5. When the connection status is "didPrinterOnline", put the sample app into
-     the background
+     the background by pressing the home button on the iOS device
   6. Turn off the connected BT Printer
   7. Bring the sample back into the foreground, printer status now displays "Initial connection failed"
   8. Turn back on BT printer, printer status still displays "Initial connection failed"
-  9. Printer is no longer able to connect to sample app without restarting
+  9. The only way to get the printer to connect to the sample app again is to force close and restart the app
 
   **Expected outcome:**
-  When backgrounding the app and turning off the printer, merchant should be able to connect again to the printer when they bring the app back into the foreground and power back on the printer.
+When backgrounding the sample app, turning off the printer, and then opening the app again, the app should be able to reconnect to the printer once it is switched on again.
   
   **Actual outcome:**
-  Printer never reconnects to the app after powering on without have to restart the app.
+The printer never reconnects to the sample app after powering on. An app restart is needed to get it to connect again.
 
 --------------------------------------  
   

--- a/README.md
+++ b/README.md
@@ -1,83 +1,31 @@
 # StarSampleSdk
 
-## iOS Bugs that need to be fixed
-
-#### Retrieving network printer status fails after subsequent attempts
-  **Steps to reproduce:**
-
-  1. Turn on a Wi-Fi printer.
-  2. Launch the app and press Scan Network for the app to discover the Wi-Fi printer. Select the printer from the list.
-  3. On the printer details page, press Get status, release port TWICE. Verify the printer status changes to Online.
-  4. Press Get status, release port TWICE a few more times, verifying the status is always Online.
-  5. Press Get status, release port ONCE, verify the status is Online.
-  6. Press Get status, release port ONCE again, and verify the status changes to Offline after a few seconds, with the following error message logged. Any subsequent attempt to get the printer status will result in this failure.
-
-  **Video:** https://user-images.githubusercontent.com/45129610/144146683-6999d953-2829-442d-a944-4c87c1a6213e.mp4
-  
-  **Expected outcome:**
-  We should be able to fetch the network printers status as many times as we would like, and not have to worry about the attempt to fetch the status failing. This works as expected on Android - but fails on iOS
-  
-  **Actual outcome:**
-  The first attempt to fetch the printers status will succeed, but any subsequent attempt to grab the printers status will fail with the following error: Failed to getPort. Printer is in use.
-  
---------------------------------------  
-#### Star Bluetooth printer with an active StarIoExtManager connection won't reconnect if we don't call releasePort() after a print job. As a result, calling releasePort() results in the EXC_BAD_ACCESS crashes that we have been seeing in production
-
-  **Steps to reproduce:**
-  1. Manually pair a Star Micronics Bluetooth printer to the iOS device
-  2. On the sample app, click the "Scan BT" button to discover the paired BT printer
-  3. Click on the discovered BT printer row to navigate to printer details
-  4. In the top right, click "Connect" - wait for the connection to succeed 
-  5. When the connection status is "didPrinterOnline, click "Print and do not release port" your printer should then print
-  6. Now, turn the printer off - the status should update to "didPrinterImpossible"
-  7. Turn the printer back on, see that the printer status is now "didAccessoryConnectFailure"
-  8. At this point I would expect it to be "didPrinterOnline"
-
-  **Video:** https://user-images.githubusercontent.com/45129610/144144933-d20680af-ded4-4849-a791-10733853161f.mp4
-
-  **Expected outcome:**
-  The printer should reconnect to the app after a print has completed without releasing the port. We shouldn't need to release the port after a print job, because we are using the StarIoExtManager to secure a connection with the app. 
-  
-  **Actual outcome:**
-  The printer fails the reconnect to the app after a single print job has completed. This means that the user will have to restart their app everytime the printer has been turn off/on.
-
---------------------------------------  
+## iOS Bugs
 
 #### Star Bluetooth printer with an active StarIoExtManager connection won't reconnect after calling disconnect()/connect()
 
+  **Background:**
+  This regression was introduced after addressing another bug which involved swapping between our Point of Sale app and opening another 3rd party app that also makes a connection to the BT printer. Previously we were not calling disconnec() when backgrounding and not calling connect() when foregrounding our app, and would lose connection to the Printer. After adding calls to disconnect/connect when background/foregrounding it addressed our initial connection issue, but introduced a new regression when powering off the BT printer during backgrounding and not being able to connect after powering it back on after foregrounding.
+
   **Steps to reproduce:**
   1. Manually pair a Star Micronics Bluetooth printer to the iOS device
   2. On the sample app, click the "Scan BT" button to discover the paired BT printer
   3. Click on the discovered BT printer row to navigate to printer details
   4. In the top right, click "Connect" - wait for the connection to succeed 
-  5. When the connection status is "didPrinterOnline, click "Print and do not release port" your printer should then print
-  5. In the top right, click "Disconnect" this should disconnect the StarIoExtManager instance
-  6. Click "Connect" again - observe that the Printer status is now "Initial connection failed"
-
-  **Video:** https://user-images.githubusercontent.com/45129610/144147706-3ad17a28-a3d9-4711-b403-a781abb5fe9d.mp4
+  5. When the connection status is "didPrinterOnline", put the sample app into
+     the background
+  6. Turn off the connected BT Printer
+  7. Bring the sample back into the foreground, printer status now displays "Initial connection failed"
+  8. Turn back on BT printer, printer status still displays "Initial connection failed"
+  9. Printer is no longer able to connect to sample app without restarting
 
   **Expected outcome:**
-  We should be able to disconnect/reconnect the printer regardless of if the user has previously printed or not. 
+  When backgrounding the app and turning off the printer, merchant should be able to connect again to the printer when they bring the app back into the foreground and power back on the printer.
   
   **Actual outcome:**
-  If the user has printed without releasing the port - then we can not disconnect and reconnect the StarIoExtManager
+  Printer never reconnects to the app after powering on without have to restart the app.
 
 --------------------------------------  
-
-#### Star mPOP printer has an empty macAddress in PortInfo object
-  **Steps to reproduce:**
-  1. Manually pair an mPOP printer
-  2. On the sample app, click the "Scan BT" button to discover the paired BT printer
-  3. Click on the discovered BT printer row to navigate to printer details
-  4. In the printer details, see that the macAddress field is an empty string
-  
-  **Video:** https://user-images.githubusercontent.com/45129610/144145102-fc8ab567-b5ee-41f8-8fc2-247d58d2422a.mp4
-
-  **Expected outcome:**
-  Every BT device has a macAddress, so the PortInfo object should be populated correctly when the mPOP printer is discovered. This is how we uniquely identify printers. 
-  
-  **Actual outcome:**
-  The macAddress field on the PortInfo object is empty when an mPOP printer is discovered
   
 ## Background Context
 

--- a/src/ios/StarSampleApp/StarSampleApp/views/PrinterDetailsView.swift
+++ b/src/ios/StarSampleApp/StarSampleApp/views/PrinterDetailsView.swift
@@ -29,11 +29,11 @@ struct PrinterDetailsView: View {
                 }
                 HStack(spacing: 20.0) {
                     Button("Print and release port (Wi-Fi Printers)", action: {
-                        viewModel.print(releasePort: true)
+                        viewModel.printReceipt(releasePort: true)
                     }).disabled(viewModel.isPrinting || viewModel.printerStatus == "Uninitialized")
                     
                     Button("Print do not release port (Bluetooth Printers)", action: {
-                        viewModel.print(releasePort: false)
+                        viewModel.printReceipt(releasePort: false)
                     }).disabled(viewModel.isPrinting || viewModel.printerStatus == "Uninitialized")
                 }.padding(.top, 40.0)
                 HStack(spacing: 20.0) {
@@ -76,7 +76,7 @@ struct PrinterDetailsView: View {
 
 struct PrinterDetails_Previews: PreviewProvider {
     static var previews: some View {
-        PrinterDetailsView(viewModel: PrinterDetailsViewModel(starManager: IosStarManager.companion.create()), portInfo: TestPortInfo())
+        PrinterDetailsView(viewModel: PrinterDetailsViewModel(starManager: IosStarManager.companion.create(), portInfo: TestPortInfo()), portInfo: TestPortInfo())
     }
 }
 

--- a/src/ios/StarSampleApp/StarSampleApp/views/PrinterListView.swift
+++ b/src/ios/StarSampleApp/StarSampleApp/views/PrinterListView.swift
@@ -31,7 +31,7 @@ struct PrinterListView: View {
                 }.padding()
                 if let list = viewModel.printerList {
                     List(list, id: \.macAddress) { portInfo in
-                        NavigationLink(destination: PrinterDetailsView(viewModel: PrinterDetailsViewModel(starManager: starManager), portInfo: portInfo)) {
+						NavigationLink(destination: PrinterDetailsView(viewModel: PrinterDetailsViewModel(starManager: starManager, portInfo: portInfo), portInfo: portInfo)) {
                             VStack(alignment: .leading) {
                                 Text(portInfo.modelName)
                                 Text(portInfo.macAddress)


### PR DESCRIPTION
This PR updates the sample app to automatically call `starIoExtManager.disconnect()` if connected to printer when the app is backgrounded, and subsequently `starIoExtManager.connect()` when the app is foregrounded again.  This was added to be able to reproduce an error we're seeing in POS.  The app will fail to reconnect to a printer in the case where the printer is switched off while the app is backgrounded, and not turned on again until after the app is foregrounded again.